### PR TITLE
changed the URL of API to ver.1.1

### DIFF
--- a/oauth.py
+++ b/oauth.py
@@ -374,7 +374,7 @@ class TwitterClient(OAuthClient):
     """
 
     response = self.make_request(
-        "http://api.twitter.com/account/verify_credentials.json",
+        "http://api.twitter.com/1.1/account/verify_credentials.json",
         token=access_token, secret=access_secret, protected=True)
 
     data = json.loads(response.content)


### PR DESCRIPTION
old version of the URL is not available.
returns errors.

 {"errors":[{"message":"Sorry, that page does not exist","code":34}]}
